### PR TITLE
Added docker and fixed config bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ allow from all
 8.	Use the administration interface to change the passwords/user names to secure your system. The initial administrator password is ‘pass1’.
 9.	You’re all set! 
 
+##Usage with Docker
+1.  Build docker container.
+```
+cd docker
+./build.sh
+```
+2.  Run docker container. The default port in script is 8085
+```
+cd ../
+./start_docker.sh
+```
+3.  You can now use rstWeb in your browser at: http://127.0.0.1:8085/rstweb/open.py
+
 ## Troubleshooting
 If you’re having trouble, it’s possible some permissions are set incorrectly, or that your server needs to be configured to execute the Python scripts. Otherwise, the entry point for the program is the script open.py. If you’re using the Apache configuration above, this acts as the directory index, so you can simply direct users to `http://.../<rstwebsdirectory>/`. 
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ allow from all
 8.	Use the administration interface to change the passwords/user names to secure your system. The initial administrator password is ‘pass1’.
 9.	You’re all set! 
 
-##Usage with Docker
+## Usage with Docker
 1.  Build docker container.
 ```
 cd docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian
-RUN apt-get update
+RUN apt-get -yqq update
 RUN apt-get install -yqq supervisor apache2
 RUN a2enmod rewrite
 RUN a2enmod cgi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian
+RUN apt-get update
+RUN apt-get install -yqq supervisor apache2
+RUN a2enmod rewrite
+RUN a2enmod cgi
+ADD apache-config.conf /etc/apache2/sites-enabled/000-default.conf
+ADD supervisord.conf /etc/supervisor/conf.d/
+CMD ["supervisord"]

--- a/docker/apache-config.conf
+++ b/docker/apache-config.conf
@@ -1,0 +1,22 @@
+Alias "/rstweb" "/var/www/html/rstweb"
+<Directory "/var/www/html/rstweb/">
+	RewriteEngine On
+	RewriteBase /
+	DirectoryIndex open.py
+
+	<IfModule mime_module>
+		AddType application/x-httpd-py .py
+	</IfModule>
+
+	RedirectMatch 404 ".+\.(py(c|o)|db|txt|rs3|ini)$"
+	RedirectMatch 404 ".*/(modules|export|import|templates|users).*$"
+
+	AddType text/html *
+	Options Indexes FollowSymLinks MultiViews
+	Options +FollowSymLinks
+	Options +ExecCGI
+	AddHandler cgi-script .py
+	AllowOverride None
+	Order allow,deny
+	allow from all
+</Directory>

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+CURDIR=$(dirname $0)
+docker build -t rstweb $CURDIR

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,7 @@
+[supervisord]
+nodaemon=true
+
+[program:apache]
+command=/usr/sbin/apache2ctl -DFOREGROUND
+autorestart=true
+startretries=5

--- a/modules/configobj.py
+++ b/modules/configobj.py
@@ -323,8 +323,8 @@ class Section(dict):
                     indict=value,
                     name=key))
         else:
-            if not key in self.__dict__:
-                self.scalars.append(key)
+            if (not key in self.__dict__) and (not key in self): #There was just 'not key in self.__dict__' condition
+                self.scalars.append(key)                         #Maybe whe should delete 'not key in self.__dict__'?
             if not self.main.stringify:
                 if isinstance(value, StringTypes):
                     pass
@@ -932,6 +932,8 @@ class ConfigObj(Section):
             error.errors = self._errors
             # set the config attribute
             error.config = self
+            print >> sys.stderr, str('Error: There is a problem in user config file!')
+            print >> sys.stderr, str(self._errors)
             raise error
         # delete private attributes
         del self._errors

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+CURDIR=`pwd`/$(dirname $0)
+docker rm -f rstweb
+docker run -d -p 8085:80 --name rstweb -v $CURDIR:/var/www/html/rstweb rstweb


### PR DESCRIPTION
Hi!
I propose two changes:

1. I have added docker in the project. I often need to deploy this project on different devices. The Docker greatly accelerates this process.


2. There was a bug in configobj.py.
Firstly, After authorization as administrator (didn't try other accounts) the application stopped working.
It stopped working because there was an error in the config file "users/admin.ini". I understood this as a result of debugging. Added a message output to the error log in this case.

But how appeared mistake in the config file?
In 'modules/configobj.py' list self.scalars had elements 'lastused' and 'numused' two times. For this reason, there was a duplication of rows in config file. This was due to an incorrect condition.
Perhaps the condition in the file 'modules/configobj.py'  on the line 326 needs to be deleted.