### PR TITLE
Added warning for broken segmentation and filtering of empty lines

### DIFF
--- a/modules/rstweb_reader.py
+++ b/modules/rstweb_reader.py
@@ -155,17 +155,17 @@ def read_text(filename,rel_hash):
 	rels = collections.OrderedDict(sorted(rel_hash.items()))
 
 	for line in f:
-		id_counter += 1
 		contents = line.strip()
+		if len(contents) > 0:
+			id_counter += 1
+			# Check for invalid XML in segment contents
+			if "<" in contents or ">" in contents or "&" in contents:
+				contents = contents.replace('>','&gt;')
+				contents = contents.replace('<', '&lt;')
+				contents = re.sub(r'&([^ ;]* )', r'&amp;\1', contents)
+				contents = re.sub(r'&$', r'&amp;', contents)
 
-		# Check for invalid XML in segment contents
-		if "<" in contents or ">" in contents or "&" in contents:
-			contents = contents.replace('>','&gt;')
-			contents = contents.replace('<', '&lt;')
-			contents = re.sub(r'&([^ ;]* )', r'&amp;\1', contents)
-			contents = re.sub(r'&$', r'&amp;', contents)
-
-		nodes[str(id_counter)] = NODE(str(id_counter),id_counter,id_counter,"0",0,"edu",contents,rels.keys()[0],rels.values()[0])
+			nodes[str(id_counter)] = NODE(str(id_counter),id_counter,id_counter,"0",0,"edu",contents,rels.keys()[0],rels.values()[0])
 
 	return nodes
 

--- a/segment.py
+++ b/segment.py
@@ -160,6 +160,7 @@ def segment_main(user, admin, mode, **kwargs):
 
 	cpout += '\t<script src="script/segment.js"></script>'
 	cpout += '<h2>Edit segmentation</h2>'
+	cpout += '%(warning)s'
 	cpout += '\t<div id="control">'
 	cpout += '\t<p>Document: <b>'+current_doc+'</b> (project: <i>'+current_project+'</i>)</p>'
 	cpout += '\t<div id="segment_canvas">'
@@ -172,6 +173,7 @@ def segment_main(user, admin, mode, **kwargs):
 	tok_counter=0
 
 	segs = collections.OrderedDict(sorted(segs.items()))
+	del_token_to_seg = {}
 	first_seg = True
 	for seg_id in segs:
 		first_tok = True
@@ -182,6 +184,7 @@ def segment_main(user, admin, mode, **kwargs):
 		else:
 			cpout += '<div class="tok_space" id="tok'+str(tok_counter)+'" style="display:none" onclick="act('+"'ins:"+'tok'+str(tok_counter)+"'"+')">&nbsp;</div>'
 			cpout += '\t\t\t<div id="segend_post_tok'+str(tok_counter)+'" class="seg_end" onclick="act('+"'del:"+'tok'+str(tok_counter)+"'"+')">||</div>'
+			del_token_to_seg[tok_counter] = seg_counter
 			cpout += '\t\t</div>'
 		cpout += '\t\t<div id="seg'+ str(seg_counter) +'" class="seg">'
 		for token in seg.tokens:
@@ -197,6 +200,18 @@ def segment_main(user, admin, mode, **kwargs):
 	</html>
 
 	'''
+
+	tok_seg_map = get_tok_map(current_doc,current_project,user)
+	incorrect_segs = [token_key for token_key in del_token_to_seg if int(tok_seg_map[token_key])+1 != del_token_to_seg[token_key]]
+	warning = ''
+	if len(incorrect_segs) > 0:
+		warning = '<p class="warn">Attention! The markup is broken! Don\'t mark! Contact with your administrator.</p>'
+
+	cpout %= {
+		'warning' : warning
+	}
+
+
 	if mode != "server":
 		cpout = cpout.replace(".py","")
 	return cpout


### PR DESCRIPTION
**Problem description:**
Suppose you add the following text to the system:
```
First string

Second string
Third string

```
After, you will see the following situation in segmentation:
![_020](https://user-images.githubusercontent.com/12899566/45825440-edaa3180-bcfa-11e8-9e5d-41b81e345e0b.png)

Suppose you delete the first delimiter and save:
![_021](https://user-images.githubusercontent.com/12899566/45825485-07e40f80-bcfb-11e8-9b1f-8d7883e2e376.png)

Later, you remove the delimiter as on the picture:
![_022](https://user-images.githubusercontent.com/12899566/45825715-8fca1980-bcfb-11e8-9c50-c52871e0f26a.png)

When you will save it, you will see the following situation:
![_023](https://user-images.githubusercontent.com/12899566/45825757-a96b6100-bcfb-11e8-9737-b963e7bdde76.png)

**Why did this happen?**
An empty token remains in the database, but it is not in the segmentation HTML. An empty token disappears due to the 'strip()'.
```python
def get_tok_map(doc,project,user):
	rows = generic_query("SELECT id, contents FROM rst_nodes WHERE kind='edu' and doc=? and project=? and user=? ORDER BY CAST(id AS int)",(doc,project,user))
	all_tokens = {}
	token_counter = 0
	for row in rows:
		edu_text = row[1].strip()
		edu_tokens = edu_text.split(" ")
		for token in edu_tokens:
			token_counter += 1
			all_tokens[token_counter] = row[0]

	return all_tokens
```

**Decision**
Added the warning if the markup is broken:
![_024](https://user-images.githubusercontent.com/12899566/45827064-6068dc00-bcfe-11e8-8ba2-7b3241a84ef2.png)

The system ignores empty lines in text, when user uploads txt:
![_025](https://user-images.githubusercontent.com/12899566/45827193-96a65b80-bcfe-11e8-9900-08e30b609a88.png)

