### PR TITLE
Replace multiple spaces during import

### DIFF
--- a/modules/rstweb_reader.py
+++ b/modules/rstweb_reader.py
@@ -191,6 +191,8 @@ def read_text(filename,rel_hash,do_tokenize=False):
 		contents = line.strip()
 		if len(contents) > 0:
 			id_counter += 1
+			# Replace multiple spaces
+			contents = re.sub(r'\s{2,}', r' ', contents)
 			# Check for invalid XML in segment contents
 			if "<" in contents or ">" in contents or "&" in contents:
 				contents = contents.replace('>','&gt;')


### PR DESCRIPTION
Segmentation occurs with errors if text has several spaces in a row.
Example:
Original text -> 'How   are you doing?' (there are 3 spaces between 'How' and 'are'. Github doesn't show it in preview mode)
if you segment it like 'How   |are| you doing?'
you will recieve 'How | are you doing?|'

It happens because the tool suppose the space as the token.

I added the regex for replacing multi spaces to one space.